### PR TITLE
 factory and method for access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0
+- Add new factory and methods
+
 ## 1.1.3
 - Fix params default in http actions
 

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -20,7 +20,7 @@ class MP {
 
   /// Set access token
   /// return void
-  void setAccessToken(String token) async {
+  void setAccessToken(String token) {
     this._access_token = token;
   }
 

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -4,14 +4,24 @@ import 'dart:core';
 import 'rest_client.dart';
 
 class MP {
-  final String _client_id;
-  final String _client_secret;
+  String _client_id;
+  String _client_secret;
 
   String _access_token;
   MPRestClient _restClient;
 
   MP(this._client_id, this._client_secret) {
     _restClient = MPRestClient();
+  }
+
+  MP.fromAccessToken(this._access_token) {
+    _restClient = MPRestClient();
+  }
+
+  /// Set access token
+  /// return void
+  void setAccessToken(String token) async {
+    this._access_token = token;
   }
 
   /// Get access token

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String SDK_VERSION = '1.2.3';
+const String SDK_VERSION = '1.2.0';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String SDK_VERSION = '1.1.3';
+const String SDK_VERSION = '1.2.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Mercadopago SDK module for Payments integration
   for use in applications web, server, flutter
 homepage: https://github.com/bmkeros/mercadopago_sdk_dart
-version: 1.2.3
+version: 1.2.0
 
 dependencies:
   http: ^0.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Mercadopago SDK module for Payments integration
   for use in applications web, server, flutter
 homepage: https://github.com/bmkeros/mercadopago_sdk_dart
-version: 1.1.3
+version: 1.2.3
 
 dependencies:
   http: ^0.12.0


### PR DESCRIPTION
Add new changes

1) Using factory

    ```
    var map = MP.fromAccessToken('MYACCESSTOKEN');
    var preference = {
            "items": [
                {
                    "title": "Test",
                    "quantity": 1,
                    "currency_id": "USD",
                    "unit_price": 10.4
                }
            ]
        };
    var result = await mp.createPreference(preference);```

2) Using method

    ```
    var mp = MP("CLIENT_ID", "CLIENT_SECRET");
    var preference = {
            "items": [
                {
                    "title": "Test",
                    "quantity": 1,
                    "currency_id": "USD",
                    "unit_price": 10.4
                }
            ]
        };
    // Change access token
   mp.setAccessToken('MYACCESSTOKEN');
    var result = await mp.createPreference(preference);```
